### PR TITLE
iOS 18 Fixes

### DIFF
--- a/Sources/MoreData/Fetchable/FetchableResultsPublisher.swift
+++ b/Sources/MoreData/Fetchable/FetchableResultsPublisher.swift
@@ -165,6 +165,13 @@ public class FetchableResultsPublisher<ResultType>: NSObject, NSFetchedResultsCo
         // https://developer.apple.com/documentation/coredata/nsfetchedresultscontroller#overview
         frc.delegate = self
         try frc.performFetch()
+
+        // Initial diff: inserting all objects
+        diff = .init(
+            frc.fetchedObjects?.enumerated().map({ (index, entity) in
+                CollectionDifference<NSManagedObjectID>.Change.insert(offset: index, element: entity.objectID, associatedWith: nil)
+            }) ?? []
+        )
     }
 
     /// Stops monitoring changes and pauses the fetch operation.


### PR DESCRIPTION
Behavior seems to have changed with iOS 18! Now the delegate method `didChangeContentWith` is only called on updates and not on initial fetch, it seems. This means it's necessary to trigger publisher on initial fetch as well

Tested with sample app and this resolved data loading issues on iOS 18